### PR TITLE
✨ Adicionando parametro timeout

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -36,16 +36,20 @@ class Rest implements RestInterface
      */
     protected $proxy = [];
 
+    protected $timeout;
+
     /**
      * Constructor
      *
      * @param array $proxy Parameter for proxy ['IP','PORT','USER','PASS']
      */
-    public function __construct($proxy = [])
+    public function __construct($proxy = [], $timeout = 10)
     {
         if (!empty($proxy)) {
             $this->proxy = $proxy;
         }
+
+        $this->timeout = $timeout;
     }
 
     /**
@@ -64,7 +68,7 @@ class Rest implements RestInterface
             $this->setProxy($oCurl, $this->proxy);
         }
         curl_setopt($oCurl, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($oCurl, CURLOPT_TIMEOUT, 10);
+        curl_setopt($oCurl, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($oCurl, CURLOPT_CONNECTTIMEOUT, 30);
         curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($oCurl, CURLOPT_SSL_VERIFYPEER, 0);


### PR DESCRIPTION
Estou implementando a API do Ibpt e quando tentei adicionar em produção não estava funcionando, e depois de vários testes descobri que a API está bastante lenta e como o timeout padrão estava definido em 10s adicionei um parametro a classe `Rest` para conseguir configurar caso seja necessário.